### PR TITLE
Update abstractCleaner.py

### DIFF
--- a/abstractCleaner.py
+++ b/abstractCleaner.py
@@ -24,12 +24,13 @@ def authorScraper(tempList):
 			author = re.sub(r'\\author{', "", entry[0])
 			author = re.sub(r'}%', "", author)
 			author = re.sub('\t', "", author)
+			author = re.sub(r'%% Your name', '', author)
 			break
 	return author
 
 def cleaner(fileName):
 
-	remove0 = "documentclass{abstractYRW.cls}"
+	remove0 = "\\documentclass{abstractYRW}%"
 	remove1 = "begin{document}"
 	remove2 = "end{document}"
 	temp = []
@@ -65,7 +66,8 @@ def main():
 		if run.lower().startswith("y"):
 			runBool = True
 		if runBool == False:
-			exit()
+			print('quitting')
+			quit()
 
 	for abstract in absFiles:
 		nextAuthor = cleaner(abstract)


### PR DESCRIPTION
fixed error where the comments clarifying the \author command were not removed in the final author/abstract list and fixed error where the document class was not removed. Fixed bug where script was no longer terminating when user selected 'quit' at repeat run notification.